### PR TITLE
Avoid memory corruption

### DIFF
--- a/FCollada/FUtils/FUBoundingSphere.cpp
+++ b/FCollada/FUtils/FUBoundingSphere.cpp
@@ -178,7 +178,7 @@ FUBoundingSphere FUBoundingSphere::Transform(const FMMatrix44& transform) const
 		FMVector3(0.0f, 0.0f, radius)
 	};
 
-	for (size_t i = 0; i < 6; ++i)
+	for (size_t i = 0; i < 3; ++i)
 	{
 		testPoints[i] = transform.TransformVector(testPoints[i]);
 		float lengthSquared = testPoints[i].LengthSquared();


### PR DESCRIPTION
- don't iterate over 6 testPoints and write back to them, when you only have 3